### PR TITLE
TASK-85

### DIFF
--- a/src/main/java/br/com/finsavior/service/impl/UserServiceImpl.java
+++ b/src/main/java/br/com/finsavior/service/impl/UserServiceImpl.java
@@ -39,6 +39,8 @@ import java.util.Optional;
 @Slf4j
 public class UserServiceImpl implements UserService {
 
+    private final static Long MAX_PROFILE_IMAGE_SIZE_KB = 5120L;
+
     private final UserRepository userRepository;
     private final DeleteAccountProducer deleteAccountProducer;
     private final Environment environment;
@@ -113,6 +115,13 @@ public class UserServiceImpl implements UserService {
 
         Optional<UserProfile> userProfile = Optional.ofNullable(userProfileRepository.getByUserId(user.getId()));
         GenericResponseDTO response = new GenericResponseDTO();
+
+        if((profileData.getSize()/1024) > MAX_PROFILE_IMAGE_SIZE_KB) {
+            response.setMessage("Tamanho máximo do arquivo excedido: 5MB");
+            response.setStatus(HttpStatus.BAD_REQUEST.name());
+
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
+        }
 
         try {
             if(userProfile.isPresent()) {


### PR DESCRIPTION
O que foi feito: 
Limitação de tamanho do arquivo da foto de perfil.

Por que:
https://trello.com/c/NcEaGAfu/85-trocar-table-por-um-componente-do-angular-material-mat-table-e-adicionar-limite-de-tamanho-de-upload-de-arquivo-de-foto-de-perfi